### PR TITLE
Shuffle files around to prepare metrics-unix

### DIFF
--- a/metrics.opam
+++ b/metrics.opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 maintainer:   "thomas@gazagnaire.org"
-authors:      ["Thomas Gazagnaire" "Thomas Leonard"]
+authors:      ["Thomas Gazagnaire"]
 license:      "ISC"
 homepage:     "https://github.com/samoht/metrics"
 bug-reports:  "https://github.com/samoht/metrics/issues"

--- a/src/core/jbuild
+++ b/src/core/jbuild
@@ -1,5 +1,3 @@
-(jbuild_version 1)
-
 (library
  ((name        metrics)
   (public_name metrics)

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -177,7 +177,7 @@ module Src = struct
   let kind (Src s) = (s.kind :> kind)
   let name (Src s) = s.name
   let doc (Src s) = s.doc
-  let domain (Src s) = Keys.elements s.dom
+  let tags (Src s) = Keys.elements s.dom
   let equal (Src src0) (Src src1) = src0.uid = src1.uid
   let compare (Src src0) (Src src1) =
     (Pervasives.compare : int -> int -> int) src0.uid src1.uid
@@ -209,8 +209,8 @@ let v: type a b c. (a, b, c) Src.src -> a = fun src ->
 type reporter = {
   now: unit -> int64;
   report :
-    'a 'b 'c 'd.  tags:tags -> data:data -> over:(unit -> unit) ->
-    ('a, 'b, 'd) src -> (unit -> 'c) -> 'c
+    'a.  tags:tags -> data:data -> over:(unit -> unit) -> Src.t ->
+    (unit -> 'a) -> 'a
 }
 
 let nop_reporter =
@@ -232,7 +232,7 @@ let is_active (Src.Inst src) = src.src.Src.active
 let add_no_check (Src.Inst src) f =
   let tags = src.tags in
   let data = f src.src.data in
-  report ~tags ~data ~over src.src kunit
+  report ~tags ~data ~over (Src src.src) kunit
 
 let add src f = if is_active src then add_no_check src f
 

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -331,8 +331,8 @@ let src =
   val doc : t -> string
   (** [doc src] is [src]'s documentation string. *)
 
-  val domain : t -> string list
-  (** [domain src] is the list of tags of [src] (if any).  *)
+  val tags : t -> string list
+  (** [tags src] is the list of [src]'s tag names.  *)
 
   val equal : t -> t -> bool
   (** [equal src src'] is [true] iff [src] and [src'] are the same source. *)
@@ -380,10 +380,10 @@ val check: Src.status -> ('a, 'b) result -> unit
 
 (** The type for reporters. *)
 type reporter = {
-  now: unit -> int64;
-  report :
-    'a 'b 'c 'd. tags:tags -> data:data -> over:(unit -> unit) ->
-    ('a, 'b, 'd) src -> (unit -> 'c) -> 'c
+  now   : unit -> int64;
+  report:
+    'a. tags:tags -> data:data -> over:(unit -> unit) ->
+    Src.t -> (unit -> 'a) -> 'a
 }
 
 val nop_reporter: reporter

--- a/test/core/jbuild
+++ b/test/core/jbuild
@@ -1,5 +1,3 @@
-(jbuild_version 1)
-
 (executable
  ((name      test)
   (libraries (metrics mtime.clock.os unix))))
@@ -7,4 +5,5 @@
 (alias
  ((name runtest)
   (deps (test.exe))
+  (package metrics)
   (action (run ${exe:test.exe}))))

--- a/test/core/test.ml
+++ b/test/core/test.ml
@@ -14,10 +14,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-let set_reporter () =
+(*************)
+(* Reporters *)
+(*************)
+
+let set_simple_reporter () =
   let report ~tags ~data ~over src k =
     let data_fields = Metrics.Data.fields data in
-    let name = Metrics.Src.name (Src src) in
+    let name = Metrics.Src.name src in
     let pp_field ppf f =
       Fmt.(pair ~sep:(unit "=") Metrics.pp_key Metrics.pp_value) ppf (f, f)
     in
@@ -33,7 +37,9 @@ let set_reporter () =
   let now () = Mtime_clock.now () |> Mtime.to_uint64_ns in
   Metrics.set_reporter { Metrics.report; now }
 
-(********)
+(*************)
+(*   Tests   *)
+(*************)
 
 let src =
   let open Metrics in
@@ -68,9 +74,8 @@ let status =
   let tags = Tags.[] in
   v (Src.status "status" ~tags)
 
-let () =
-  set_reporter ();
-  Metrics.enable_all ();
+
+let run () =
   f i0;
   f i1;
   let _ = Metrics.run_with_result m1 (fun () -> Ok (Unix.sleep 1)) in
@@ -80,3 +85,8 @@ let () =
   in
   Metrics.check status (Ok ());
   Metrics.check status (Error ())
+
+let () =
+  Metrics.enable_all ();
+  set_simple_reporter ();
+  run ();


### PR DESCRIPTION
Also:
- Rename Tags.domain into Tags.tags
- Simplify the type for custom reporters