### PR TITLE
wip

### DIFF
--- a/test/core/jbuild
+++ b/test/core/jbuild
@@ -1,9 +1,15 @@
 (executable
  ((name      test)
+  (modules   (Test))
   (libraries (metrics mtime.clock.os unix))))
+
+(executable
+ ((name      runtime)
+  (modules   (Runtime))
+  (libraries (metrics mtime.clock.os cstruct unix))))
 
 (alias
  ((name runtest)
-  (deps (test.exe))
+  (deps (test.exe runtime.exe))
   (package metrics)
   (action (run ${exe:test.exe}))))

--- a/test/core/runtime.ml
+++ b/test/core/runtime.ml
@@ -1,0 +1,118 @@
+(*************)
+(* Reporters *)
+(*************)
+
+let set_simple_reporter () =
+  let start = Mtime_clock.now () in
+  let report ~tags ~data ~over src k =
+    let data_fields = Metrics.Data.fields data in
+    let name = Metrics.Src.name src in
+    let pp_field ppf f =
+      Fmt.(pair ~sep:(unit "=") Metrics.pp_key Metrics.pp_value) ppf (f, f)
+    in
+    let pp = Fmt.(list ~sep:(unit ",") pp_field) in
+    let timestamp = match Metrics.Data.timestamp data with
+      | Some ts -> ts
+      | None    -> Fmt.to_to_string Mtime.Span.pp
+                     (Mtime.span start (Mtime_clock.now ()))
+    in
+    Fmt.pr "%s %a %a %s\n%!" name pp tags pp data_fields timestamp;
+    over ();
+    k ()
+  in
+  let now () = Mtime_clock.now () |> Mtime.to_uint64_ns in
+  Metrics.set_reporter { Metrics.report; now }
+
+(*************)
+(*   Tests   *)
+(*************)
+
+let src =
+  let open Metrics in
+  let tags = Tags.[
+      string "hostname";
+    ] in
+  let data stat =
+    Data.v [
+      float "minor words" stat.Gc.minor_words ;
+      float "promoted words" stat.Gc.promoted_words ;
+      float "major words" stat.Gc.major_words ;
+      uint "minor collections" stat.Gc.minor_collections ;
+      uint "major collections" stat.Gc.major_collections ;
+      uint "heap words" stat.Gc.heap_words ;
+      uint "heap chunks" stat.Gc.heap_chunks ;
+      uint "compactions" stat.Gc.compactions ;
+      uint "top heap words" stat.Gc.top_heap_words ;
+      uint "stack size" stat.Gc.stack_size ;
+    ] in
+  Src.v "quick runtime" ~tags ~data
+
+let full_src =
+  let open Metrics in
+  let tags = Tags.[
+      string "hostname";
+    ] in
+  let data stat =
+    Data.v [
+      float "minor words" stat.Gc.minor_words ;
+      float "promoted words" stat.Gc.promoted_words ;
+      float "major words" stat.Gc.major_words ;
+      uint "minor collections" stat.Gc.minor_collections ;
+      uint "major collections" stat.Gc.major_collections ;
+      uint "heap words" stat.Gc.heap_words ;
+      uint "heap chunks" stat.Gc.heap_chunks ;
+      uint "compactions" stat.Gc.compactions ;
+      uint "live words" stat.Gc.live_words ;
+      uint "live blocks" stat.Gc.live_blocks ;
+      uint "free words" stat.Gc.free_words ;
+      uint "free blocks" stat.Gc.free_blocks ;
+      uint "largest free" stat.Gc.largest_free ;
+      uint "fragments" stat.Gc.fragments ;
+      uint "top heap words" stat.Gc.top_heap_words ;
+      uint "stack size" stat.Gc.stack_size ;
+    ] in
+  Src.v "runtime" ~tags ~data
+
+let i = Metrics.v src "localhost"
+let i2 = Metrics.v full_src "localhost"
+
+let timer =
+  let open Metrics in
+  let tags = Tags.[string "function"] in
+  Src.timer "duration" ~tags
+
+let m_quick = Metrics.v timer "quick_stat"
+let m_stat = Metrics.v timer "stat"
+
+let f () =
+  let _ = Metrics.run m_quick Gc.quick_stat in
+  Metrics.add i2 (fun m -> m (Metrics.run m_stat (fun () -> Gc.stat ()))) ;
+  Metrics.add i (fun m -> m (Metrics.run m_quick (fun () -> Gc.quick_stat ())))
+
+let mem = Hashtbl.create 2
+
+let rec alloc n =
+  match Hashtbl.find_opt mem n with
+  | Some v -> v
+  | None ->
+    let r =
+      let rec alloc = function
+        | 0 -> ["hallo"]
+        | n -> string_of_int n :: alloc (pred n)
+      in
+      alloc n
+    in
+    Hashtbl.add mem n r ;
+    r
+
+let run () =
+  for i = 0 to 1000 do
+    f () ;
+    let _ = alloc i in
+    Unix.sleep 1
+  done
+
+let () =
+  Metrics.enable_all ();
+  set_simple_reporter ();
+  run ();


### PR DESCRIPTION
this is only work-in-progress, but I've a question: why does the first `quick_stat` call takes so much time, compared to the others?  if I reorder the calls in `f ()`, always the first one takes a long time...

some output:
```
duration function=quick_stat duration=4144,status=ok 5min28s
duration function=stat duration=544353,status=ok 5min28s
runtime hostname=localhost minor words=2.26705e+06,promoted words=223590,major words=223590,minor collections=9,major collections=2,heap words=491520,heap chunks=1,compactions=0,live words=222008,live blocks=88077,free words=269512,free blocks=249,largest free=267930,fragments=0,top heap words=491520,stack size=37 5min28s
duration function=quick_stat duration=344,status=ok 5min28s
quick runtime hostname=localhost minor words=2.27017e+06,promoted words=223590,major words=223590,minor collections=9,major collections=2,heap words=491520,heap chunks=1,compactions=0,top heap words=491520,stack size=35 5min28s
duration function=quick_stat duration=4384,status=ok 5min29s
duration function=stat duration=562169,status=ok 5min29s
runtime hostname=localhost minor words=2.27499e+06,promoted words=223590,major words=223590,minor collections=9,major collections=2,heap words=491520,heap chunks=1,compactions=0,live words=222008,live blocks=88077,free words=269512,free blocks=249,largest free=267930,fragments=0,top heap words=491520,stack size=37 5min29s
duration function=quick_stat duration=433,status=ok 5min29s
quick runtime hostname=localhost minor words=2.27812e+06,promoted words=223590,major words=223590,minor collections=9,major collections=2,heap words=491520,heap chunks=1,compactions=0,top heap words=491520,stack size=35 5min29s
```