### PR TITLE
add ocaml_runtime and ocaml_runtime_quick sources to Metrics

### DIFF
--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -317,7 +317,8 @@ let disable_all () =
   Src._tags.tags <- Keys.empty;
   Src.update ()
 
-let ocaml_runtime_quick ~tags =
+let gc_quick_stat ~tags =
+  let doc = "OCaml memory management counters (quick)" in
   let data () =
     let stat = Gc.quick_stat () in
     Data.v [
@@ -332,9 +333,10 @@ let ocaml_runtime_quick ~tags =
       uint "top heap words" stat.Gc.top_heap_words ;
       uint "stack size" stat.Gc.stack_size ;
     ] in
-  Src.v "OCaml runtime quick" ~tags ~data
+  Src.v ~doc ~tags ~data "gc quick"
 
-let ocaml_runtime ~tags =
+let gc_stat ~tags =
+  let doc = "OCaml memory management counters" in
   let data () =
     let stat = Gc.stat () in
     Data.v [
@@ -355,4 +357,4 @@ let ocaml_runtime ~tags =
       uint "top heap words" stat.Gc.top_heap_words ;
       uint "stack size" stat.Gc.stack_size ;
     ] in
-  Src.v "OCaml runtime" ~tags ~data
+  Src.v ~doc ~tags ~data "gc"

--- a/src/core/metrics.ml
+++ b/src/core/metrics.ml
@@ -316,3 +316,43 @@ let disable_all () =
   Src._tags.all <- false;
   Src._tags.tags <- Keys.empty;
   Src.update ()
+
+let ocaml_runtime_quick ~tags =
+  let data () =
+    let stat = Gc.quick_stat () in
+    Data.v [
+      float "minor words" stat.Gc.minor_words ;
+      float "promoted words" stat.Gc.promoted_words ;
+      float "major words" stat.Gc.major_words ;
+      uint "minor collections" stat.Gc.minor_collections ;
+      uint "major collections" stat.Gc.major_collections ;
+      uint "heap words" stat.Gc.heap_words ;
+      uint "heap chunks" stat.Gc.heap_chunks ;
+      uint "compactions" stat.Gc.compactions ;
+      uint "top heap words" stat.Gc.top_heap_words ;
+      uint "stack size" stat.Gc.stack_size ;
+    ] in
+  Src.v "OCaml runtime quick" ~tags ~data
+
+let ocaml_runtime ~tags =
+  let data () =
+    let stat = Gc.stat () in
+    Data.v [
+      float "minor words" stat.Gc.minor_words ;
+      float "promoted words" stat.Gc.promoted_words ;
+      float "major words" stat.Gc.major_words ;
+      uint "minor collections" stat.Gc.minor_collections ;
+      uint "major collections" stat.Gc.major_collections ;
+      uint "heap words" stat.Gc.heap_words ;
+      uint "heap chunks" stat.Gc.heap_chunks ;
+      uint "compactions" stat.Gc.compactions ;
+      uint "live words" stat.Gc.live_words ;
+      uint "live blocks" stat.Gc.live_blocks ;
+      uint "free words" stat.Gc.free_words ;
+      uint "free blocks" stat.Gc.free_blocks ;
+      uint "largest free" stat.Gc.largest_free ;
+      uint "fragments" stat.Gc.fragments ;
+      uint "top heap words" stat.Gc.top_heap_words ;
+      uint "stack size" stat.Gc.stack_size ;
+    ] in
+  Src.v "OCaml runtime" ~tags ~data

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -400,6 +400,26 @@ val reporter: unit -> reporter
 val set_reporter: reporter -> unit
 (** [set_reporter r] sets the current reporter to [r]. *)
 
+
+(** {2:runtime OCaml runtime source}
+
+    The {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html}Gc} module
+   of the OCaml system provides
+   {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#TYPEstat}counters}
+   of the memory management via
+   {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#VALquick_stat}Gc.quick_stat}
+   and
+   {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#VALstat}Gc.stat}
+    function.  Both are provided here. *)
+
+val ocaml_runtime: tags:'a Tags.t -> ('a, unit -> data) src
+(** [ocaml_runtime ~tags] is the source of OCaml's [Gc.stat ()] memory
+   management counters. *)
+
+val ocaml_runtime_quick: tags:'a Tags.t -> ('a, unit -> data) src
+(** [ocaml_runtime_quick ~tags] is the source of OCaml's [Gc.quick_stat ()]
+   memory management counters. *)
+
 (**/*)
 val report:
   ('a, 'b) src ->

--- a/src/core/metrics.mli
+++ b/src/core/metrics.mli
@@ -401,7 +401,7 @@ val set_reporter: reporter -> unit
 (** [set_reporter r] sets the current reporter to [r]. *)
 
 
-(** {2:runtime OCaml runtime source}
+(** {2:runtime OCaml Gc sources}
 
     The {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html}Gc} module
    of the OCaml system provides
@@ -412,13 +412,13 @@ val set_reporter: reporter -> unit
    {{:http://caml.inria.fr/pub/docs/manual-ocaml/libref/Gc.html#VALstat}Gc.stat}
     function.  Both are provided here. *)
 
-val ocaml_runtime: tags:'a Tags.t -> ('a, unit -> data) src
-(** [ocaml_runtime ~tags] is the source of OCaml's [Gc.stat ()] memory
-   management counters. *)
+val gc_stat: tags:'a Tags.t -> ('a, unit -> data) src
+(** [gc_stat ~tags] is the source of OCaml's [Gc.stat ()] memory management
+    counters. *)
 
-val ocaml_runtime_quick: tags:'a Tags.t -> ('a, unit -> data) src
-(** [ocaml_runtime_quick ~tags] is the source of OCaml's [Gc.quick_stat ()]
-   memory management counters. *)
+val gc_quick_stat: tags:'a Tags.t -> ('a, unit -> data) src
+(** [gc_quick_stat ~tags] is the source of OCaml's [Gc.quick_stat ()] memory
+    management counters. *)
 
 (**/*)
 val report:


### PR DESCRIPTION
I'm not entirely sure where to put these two... since they only depend on `Gc`, I guess it is safe to put them here?